### PR TITLE
Small changes to speed up local development

### DIFF
--- a/content-cache/tests/conftest.py
+++ b/content-cache/tests/conftest.py
@@ -14,3 +14,8 @@ def pytest_addoption(parser: Parser):
         parser: The pytest argument parser.
     """
     parser.addoption("--charm-file", action="store", help="The prebuilt content-cache charm file.")
+    parser.addoption(
+        "--config-charm-file",
+        action="store",
+        help="The prebuilt content-cache-backends-config charm file.",
+    )

--- a/content-cache/tests/integration/conftest.py
+++ b/content-cache/tests/integration/conftest.py
@@ -50,8 +50,15 @@ def charm_file_fixture(pytestconfig: pytest.Config) -> str:
 
 
 @pytest_asyncio.fixture(name="config_charm_file", scope="module")
-async def config_charm_file_fixture(ops_test: OpsTest) -> AsyncIterator[str]:
+async def config_charm_file_fixture(
+    ops_test: OpsTest, pytestconfig: pytest.Config
+) -> AsyncIterator[str]:
     """Build the configuration charm file and return the path."""
+    file = pytestconfig.getoption("--config-charm-file")
+    if file:
+        yield file
+        return
+
     path = await ops_test.build_charm("../content-cache-backends-config")
     yield str(path)
 

--- a/content-cache/tests/integration/conftest.py
+++ b/content-cache/tests/integration/conftest.py
@@ -81,11 +81,15 @@ async def deploy_applications_fixture(
 ) -> AsyncIterator[dict[str, Application]]:
     """Deploy all applications in parallel."""
     if pytestconfig.getoption("--no-deploy"):
-        yield {
-            app_name: model.applications[app_name],
-            config_app_name: model.applications[config_app_name],
-            cert_app_name: model.applications[cert_app_name],
-        }
+        try:
+            res = {
+                app_name: model.applications[app_name],
+                config_app_name: model.applications[config_app_name],
+                cert_app_name: model.applications[cert_app_name],
+            }
+        except KeyError:
+            raise RuntimeError("At least one app is missing, you cannot use --no-deploy.")
+        yield res
         return
 
     app_task = model.deploy(charm_file, app_name, base="ubuntu@24.04")

--- a/content-cache/tests/integration/conftest.py
+++ b/content-cache/tests/integration/conftest.py
@@ -70,8 +70,17 @@ async def deploy_applications_fixture(
     app_name: str,
     config_app_name: str,
     cert_app_name: str,
+    pytestconfig: pytest.Config,
 ) -> AsyncIterator[dict[str, Application]]:
     """Deploy all applications in parallel."""
+    if pytestconfig.getoption("--no-deploy"):
+        yield {
+            app_name: model.applications[app_name],
+            config_app_name: model.applications[config_app_name],
+            cert_app_name: model.applications[cert_app_name],
+        }
+        return
+
     app_task = model.deploy(charm_file, app_name, base="ubuntu@24.04")
     config_app_task = model.deploy(config_charm_file, config_app_name, num_units=0)
     cert_app_task = model.deploy(


### PR DESCRIPTION
### Overview

Two changes to enable reuse of existings ressources to speed up local development:
- --config-charm-file: avoid to rebuild the config charm on every run
- --no-deploy: avoid to redeploy cache/cert/config application

### Rationale

Integration tests take time to run due to the build and machine provisionning phases. By reusing existing resources we reduce the time required to run them.

### Juju Events Changes

n/a

### Module Changes

n/a

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes. 

Unchecked items are not applicable to this change.