### PR TITLE
Bug Fix: Nginx configuration conflict with multiple virtual hosts

### DIFF
--- a/content-cache/docs/changelog.md
+++ b/content-cache/docs/changelog.md
@@ -4,7 +4,7 @@
 
 ### **Fixed**
 
-- A issue when content-cache charm integrated with multiple content-cache-backends-config charm causing the configuration for the additional content-cache-backends-config charm was not being correctly included in nginx configuration.
+- A issue where content-cache charm integrated with multiple content-cache-backends-config charms causing some configuration to not work correctly.
 
 ## 2024-12-05
 

--- a/content-cache/docs/changelog.md
+++ b/content-cache/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2024-12-11
+
+### **Fixed**
+
+- A issue when content-cache charm integrated with multiple content-cache-backends-config charm causing the configuration for the additional content-cache-backends-config charm was not being correctly included in nginx configuration.
+
 ## 2024-12-05
 
 ### **Added**

--- a/content-cache/src/nginx_manager.py
+++ b/content-cache/src/nginx_manager.py
@@ -27,6 +27,7 @@ from utilities import execute_command
 logger = logging.getLogger(__name__)
 
 NGINX_CERTIFICATES_PATH = Path("/etc/nginx/certs")
+NGINX_CONF_PATH = Path("/etc/nginx/conf.d")
 NGINX_SITES_ENABLED_PATH = Path("/etc/nginx/sites-enabled")
 NGINX_SITES_AVAILABLE_PATH = Path("/etc/nginx/sites-available")
 NGINX_LOG_PATH = Path("/var/log/nginx")
@@ -138,6 +139,7 @@ def update_and_load_config(
     _reset_nginx_files()
 
     try:
+        _create_http_config()
         _create_status_page_config()
     except NginxFileError:
         logger.info("Stop updating configuration file due to file write issues")
@@ -178,29 +180,58 @@ def _load_config() -> None:  # pragma: no cover
 
 
 def _reset_nginx_files() -> None:
-    """Reset the Nginx files.
+    """Reset the Nginx files."""
+    logger.info("Resetting the nginx conf files directories.")
+    _reset_config_directory(NGINX_CONF_PATH)
+    logger.info("Resetting the nginx sites configuration files directories.")
+    _reset_config_directory(NGINX_SITES_AVAILABLE_PATH)
+    _reset_config_directory(NGINX_SITES_ENABLED_PATH)
+    logger.info("Ensure nginx cache directory is present.")
+    _ensure_directory_exist_with_ownership(NGINX_PROXY_CACHE_DIR_PATH)
 
-    Raises:
-        NginxFileError: File operation errors resetting Nginx files.
+
+def _reset_config_directory(path: Path) -> None:
+    """Reset a nginx configuration directory.
+
+    Args:
+        path: The path to the directory.
     """
     try:
-        logger.info("Resetting the nginx sites configuration files directories.")
-        if NGINX_SITES_AVAILABLE_PATH.exists():
-            shutil.rmtree(NGINX_SITES_AVAILABLE_PATH)
-        if NGINX_SITES_ENABLED_PATH.exists():
-            shutil.rmtree(NGINX_SITES_ENABLED_PATH)
+        if path.exists():
+            shutil.rmtree(path)
         # The default permission for nginx configuration files are 755.
-        NGINX_SITES_AVAILABLE_PATH.mkdir(mode=0o755, parents=True, exist_ok=True)
-        NGINX_SITES_ENABLED_PATH.mkdir(mode=0o755, parents=True, exist_ok=True)
-        NGINX_SITES_AVAILABLE_PATH.chmod(mode=0o755)
-        NGINX_SITES_ENABLED_PATH.chmod(mode=0o755)
-        logger.info("Ensure nginx cache directory is present.")
-        NGINX_PROXY_CACHE_DIR_PATH.mkdir(mode=0o755, parents=True, exist_ok=True)
-        user = pwd.getpwnam(NGINX_USER)
-        os.chown(NGINX_PROXY_CACHE_DIR_PATH, user.pw_uid, user.pw_gid)
+        path.mkdir(mode=0o755, parents=True, exist_ok=True)
     except (PermissionError, OSError, IOError) as err:
-        logger.exception("Failed to reset the nginx files.")
-        raise NginxFileError("Failed to reset nginx files") from err
+        logger.exception("Failed to reset directory %s", path)
+        raise NginxFileError(f"Failed to reset directory {path}") from err
+
+
+def _ensure_directory_exist_with_ownership(path: Path) -> None:
+    """Ensure directory exist with nginx owning the directory.
+
+    Args:
+        path: The path to the directory.
+
+    Raises:
+        NginxFileError: File operation errors creating and/or owning the directory.
+    """
+    try:
+        path.mkdir(mode=0o755, parents=True, exist_ok=True)
+        user = pwd.getpwnam(NGINX_USER)
+        os.chown(path, user.pw_uid, user.pw_gid)
+    except (PermissionError, OSError, IOError) as err:
+        logger.exception("Failed to create and/or own directory %s", path)
+        raise NginxFileError(f"Failed to create and/or own directory {path}") from err
+
+
+def _create_http_config() -> None:
+    """Create nginx HTTP configuration files."""
+    logger.info("Creating the cache log format configuration")
+    # The following should not throw any nginx.ParseError as it is static.
+    cache_log_format_config = nginx.Conf(
+        nginx.Key("log_format", f"{NGINX_CACHE_LOG_FORMAT_NAME} '{NGINX_CACHE_LOG_FORMAT}'"),
+    )
+    _store_http_config("cache_log_format", cache_log_format_config)
 
 
 def _create_status_page_config() -> None:
@@ -217,7 +248,7 @@ def _create_status_page_config() -> None:
             )
         )
     )
-    _create_and_enable_config("nginx_status", nginx_config)
+    _store_and_enable_site_config("nginx_status", nginx_config)
 
 
 def _create_server_config(
@@ -234,13 +265,15 @@ def _create_server_config(
         NginxConfigurationError: Failed to convert the configuration to nginx format.
     """
     logger.info("Creating the nginx site configuration file for hosts %s", host)
+
+    server_cache_dir = NGINX_PROXY_CACHE_DIR_PATH / host
+    _ensure_directory_exist_with_ownership(server_cache_dir)
     try:
         nginx_config = nginx.Conf(
             nginx.Key(
                 "proxy_cache_path",
-                f"{NGINX_PROXY_CACHE_DIR_PATH} use_temp_path=off levels=1:2 keys_zone={host}:10m",
+                f"{server_cache_dir} use_temp_path=off levels=1:2 keys_zone={host}:10m",
             ),
-            nginx.Key("log_format", f"{NGINX_CACHE_LOG_FORMAT_NAME} '{NGINX_CACHE_LOG_FORMAT}'"),
         )
         server_config = nginx.Server(
             nginx.Key("proxy_cache", host),
@@ -277,7 +310,7 @@ def _create_server_config(
             f"Unable to convert {host} configuration to nginx format: {configuration}"
         ) from err
 
-    _create_and_enable_config(host, nginx_config)
+    _store_and_enable_site_config(host, nginx_config)
 
 
 def _get_upstream_config_keys(config: LocationConfig) -> tuple[nginx.Key, ...]:
@@ -323,10 +356,31 @@ def _get_location_config_keys(
     return tuple(keys)
 
 
-def _create_and_enable_config(host: str, nginx_config: nginx.Conf) -> None:
-    """Store the nginx configuration and enable it.
+def _store_http_config(name: str, nginx_config: nginx.Conf) -> None:
+    """Store the nginx http configuration.
 
-    Nginx configuration files are usually stored in the sites-available path.
+    The nginx http configurations are usually stored in the conf.d path.
+    The default and common nginx settings generally will load the conf.d path as HTTP
+    configurations.
+
+    Args:
+        name: The name of the file.
+        nginx_config: The configuration to store as file.
+    """
+    try:
+        nginx.dumpf(nginx_config, _get_http_config_path(name))
+    except (PermissionError, FileNotFoundError) as err:
+        logger.exception("Issue with http configuration directories")
+        raise NginxFileError("Issue with http configuration directories") from err
+    except (OSError, IOError) as err:
+        logger.exception("File write issue with http configuration file %s", name)
+        raise NginxFileError(f"File write issue with http configuration file {name}") from err
+
+
+def _store_and_enable_site_config(host: str, nginx_config: nginx.Conf) -> None:
+    """Store the nginx site configuration and enable it.
+
+    The nginx configuration files are usually stored in the sites-available path.
     The configurations that are enabled are usually symlink to the sites-enabled path.
 
     Args:
@@ -340,11 +394,25 @@ def _create_and_enable_config(host: str, nginx_config: nginx.Conf) -> None:
         nginx.dumpf(nginx_config, _get_sites_available_path(host))
         _get_sites_enabled_path(host).symlink_to(_get_sites_available_path(host))
     except (PermissionError, FileNotFoundError) as err:
-        logger.exception("Issue with configuration directories")
-        raise NginxFileError("Issue with configuration directories") from err
+        logger.exception("Issue with site configuration directories")
+        raise NginxFileError("Issue with site configuration directories") from err
     except (OSError, IOError) as err:
-        logger.exception("File write issue with configuration file")
-        raise NginxFileError("File write issue with configuration file") from err
+        logger.exception("File write issue with site configuration file for host %s", host)
+        raise NginxFileError(
+            f"File write issue with site configuration file for host {host}"
+        ) from err
+
+
+def _get_http_config_path(name: str) -> Path:
+    """Get the http configuration file path.
+
+    Args:
+        name: The name of the configuration.
+
+    Returns:
+        The path.
+    """
+    return NGINX_CONF_PATH / f"{name}.conf"
 
 
 def _get_sites_available_path(host: str) -> Path:

--- a/content-cache/src/nginx_manager.py
+++ b/content-cache/src/nginx_manager.py
@@ -27,7 +27,7 @@ from utilities import execute_command
 logger = logging.getLogger(__name__)
 
 NGINX_CERTIFICATES_PATH = Path("/etc/nginx/certs")
-NGINX_CONF_PATH = Path("/etc/nginx/conf.d")
+NGINX_CONFD_PATH = Path("/etc/nginx/conf.d")
 NGINX_SITES_ENABLED_PATH = Path("/etc/nginx/sites-enabled")
 NGINX_SITES_AVAILABLE_PATH = Path("/etc/nginx/sites-available")
 NGINX_LOG_PATH = Path("/var/log/nginx")
@@ -152,7 +152,7 @@ def update_and_load_config(
         if host in hostname_to_cert:
             cert_path = hostname_to_cert[host]
         try:
-            _create_server_config(host, config, cert_path)
+            _create_virtualhost_config(host, config, cert_path)
         except NginxConfigurationError as err:
             errored_hosts.append(host)
             configuration_errors.append(err)
@@ -182,7 +182,7 @@ def _load_config() -> None:  # pragma: no cover
 def _reset_nginx_files() -> None:
     """Reset the Nginx files."""
     logger.info("Resetting the nginx conf files directories.")
-    _reset_config_directory(NGINX_CONF_PATH)
+    _reset_config_directory(NGINX_CONFD_PATH)
     logger.info("Resetting the nginx sites configuration files directories.")
     _reset_config_directory(NGINX_SITES_AVAILABLE_PATH)
     _reset_config_directory(NGINX_SITES_ENABLED_PATH)
@@ -251,7 +251,7 @@ def _create_status_page_config() -> None:
     _store_and_enable_site_config("nginx_status", nginx_config)
 
 
-def _create_server_config(
+def _create_virtualhost_config(
     host: str, configuration: HostConfig, certificate_path: Path | None
 ) -> None:
     """Create the nginx configuration file for a virtual host.
@@ -412,7 +412,7 @@ def _get_http_config_path(name: str) -> Path:
     Returns:
         The path.
     """
-    return NGINX_CONF_PATH / f"{name}.conf"
+    return NGINX_CONFD_PATH / f"{name}.conf"
 
 
 def _get_sites_available_path(host: str) -> Path:

--- a/content-cache/tests/integration/conftest.py
+++ b/content-cache/tests/integration/conftest.py
@@ -36,6 +36,12 @@ def config_app_name_fixture() -> str:
     return "config"
 
 
+@pytest.fixture(name="config_alt_app_name", scope="module")
+def config_alt_app_name_fixture() -> str:
+    """The application name for the alternative configuration charm."""
+    return "config-alt"
+
+
 @pytest.fixture(name="cert_app_name", scope="module")
 def cert_app_name_fixture() -> str:
     """The application name for the TLS certificate charm."""
@@ -83,6 +89,7 @@ async def deploy_applications_fixture(
     config_charm_file: str,
     app_name: str,
     config_app_name: str,
+    config_alt_app_name: str,
     cert_app_name: str,
     metric_app_name: str,
     pytestconfig: pytest.Config,
@@ -93,6 +100,7 @@ async def deploy_applications_fixture(
             res = {
                 app_name: model.applications[app_name],
                 config_app_name: model.applications[config_app_name],
+                config_alt_app_name: model.applications[config_alt_app_name],
                 cert_app_name: model.applications[cert_app_name],
                 metric_app_name: model.applications[metric_app_name],
             }
@@ -104,6 +112,9 @@ async def deploy_applications_fixture(
     app_deploy = model.deploy(charm_file, app_name, base="ubuntu@24.04")
     config_app_deploy = model.deploy(
         config_charm_file, config_app_name, base="ubuntu@24.04", num_units=0
+    )
+    config_alt_app_deploy = model.deploy(
+        config_charm_file, config_alt_app_name, base="ubuntu@24.04", num_units=0
     )
     cert_app_deploy = model.deploy(
         CERT_CHARM_NAME, cert_app_name, channel="latest/edge", base="ubuntu@22.04"
@@ -119,14 +130,15 @@ async def deploy_applications_fixture(
         revision=319,
         num_units=0,
     )
-    app, config_app, cert_app, metric_app = await asyncio.gather(
-        app_deploy, config_app_deploy, cert_app_deploy, metric_app_deploy
+    app, config_app, config_alt_app, cert_app, metric_app = await asyncio.gather(
+        app_deploy, config_app_deploy, config_alt_app_deploy, cert_app_deploy, metric_app_deploy
     )
     await model.wait_for_idle([app.name], status="blocked", timeout=15 * 60)
     await model.wait_for_idle([cert_app.name], status="active", timeout=15 * 60)
     yield {
         app_name: app,
         config_app_name: config_app,
+        config_alt_app_name: config_alt_app,
         cert_app_name: cert_app,
         metric_app_name: metric_app,
     }
@@ -146,6 +158,14 @@ async def config_app_fixture(
 ) -> AsyncIterator[Application]:
     """The configuration charm application for testing."""
     yield applications[config_app_name]
+
+
+@pytest_asyncio.fixture(name="config_alt_app", scope="module")
+async def config_alt_app_fixture(
+    config_alt_app_name: str, applications: dict[str, Application]
+) -> AsyncIterator[Application]:
+    """The alternative configuration charm application for testing."""
+    yield applications[config_alt_app_name]
 
 
 @pytest_asyncio.fixture(name="cert_app", scope="module")
@@ -197,11 +217,15 @@ async def http_ok_ip_fixture(http_ok_app: Application) -> str:
 
 @pytest_asyncio.fixture(name="cache_tester", scope="function")
 async def cache_tester_fixture(
-    model: Model, app: Application, config_app: Application, cert_app: Application
+    model: Model,
+    app: Application,
+    config_app: Application,
+    config_alt_app: Application,
+    cert_app: Application,
 ) -> AsyncIterator[CacheTester]:
     """Get the cache tester."""
     unit = app.units[0]
-    tester = CacheTester(model, app, config_app, cert_app)
+    tester = CacheTester(model, app, config_app, config_alt_app, cert_app)
 
     yield tester
 

--- a/content-cache/tests/integration/helpers.py
+++ b/content-cache/tests/integration/helpers.py
@@ -55,6 +55,7 @@ class CacheTester:
         model: Model,
         app: Application,
         config_app: Application,
+        config_alt_app: Application,
         cert_app: Application | None = None,
     ):
         """Initialize the object.
@@ -63,17 +64,26 @@ class CacheTester:
             model: The juju model containing the applications.
             app: The content-cache application.
             config_app: The configuration charm application.
+            config_alt_app: The alternative configuration charm application.
             cert_app: The TLS certification charm application.
         """
         self._model = model
         self._app = app
         self._config_app = config_app
+        self._config_alt_app = config_alt_app
         self._cert_app = cert_app
 
     async def integrate_config(self) -> None:
         """Integrate the configuration application."""
         await self._model.integrate(
             f"{self._config_app.name}:{CACHE_CONFIG_INTEGRATION_NAME}",
+            f"{self._app.name}:{CACHE_CONFIG_INTEGRATION_NAME}",
+        )
+
+    async def integrate_config_alt(self) -> None:
+        """Integrate the alternative configuration application."""
+        await self._model.integrate(
+            f"{self._config_alt_app.name}:{CACHE_CONFIG_INTEGRATION_NAME}",
             f"{self._app.name}:{CACHE_CONFIG_INTEGRATION_NAME}",
         )
 
@@ -91,12 +101,20 @@ class CacheTester:
         )
 
     async def setup_config(self, configuration: dict[str, str]) -> None:
-        """Set up configuration.
+        """Set up configuration on the configuration charm.
 
         Args:
             configuration: The configuration for the configuration charm.
         """
         await self._config_app.set_config(configuration)
+
+    async def setup_config_alt(self, configuration: dict[str, str]) -> None:
+        """Set up configuration on the alternative configuration charm.
+
+        Args:
+            configuration: The configuration for the alternative configuration charm.
+        """
+        await self._config_alt_app.set_config(configuration)
 
     async def query_cache(
         self, path: str, hostname: str, protocol: str = "http"
@@ -125,9 +143,13 @@ class CacheTester:
 
     async def reset(self) -> None:
         """Reset the state of the applications."""
-        if self._app.related_applications(CACHE_CONFIG_INTEGRATION_NAME):
-            await self._app.remove_relation(
-                CACHE_CONFIG_INTEGRATION_NAME, self._config_app.name, True
+        if self._config_app.related_applications(CACHE_CONFIG_INTEGRATION_NAME):
+            await self._config_app.remove_relation(
+                CACHE_CONFIG_INTEGRATION_NAME, self._app.name, True
+            )
+        if self._config_alt_app.related_applications(CACHE_CONFIG_INTEGRATION_NAME):
+            await self._config_alt_app.remove_relation(
+                CACHE_CONFIG_INTEGRATION_NAME, self._app.name, True
             )
         if self._app.related_applications(CERTIFICATE_INTEGRATION_NAME):
             await self._app.remove_relation(CERTIFICATE_INTEGRATION_NAME, self._app.name, True)

--- a/content-cache/tests/integration/test_basic.py
+++ b/content-cache/tests/integration/test_basic.py
@@ -197,16 +197,12 @@ async def test_charm_with_two_config_app(
     await cache_tester.integrate_config()
     await cache_tester.integrate_config_alt()
 
-    # TODO
-    pytest.set_trace()
     await model.wait_for_idle(
         [app.name, config_app.name, config_alt_app.name], status="active", timeout=10 * 60
     )
 
     response = await cache_tester.query_cache(path="/", hostname=hostname)
     response_alt = await cache_tester.query_cache(path="/", hostname=hostname_alt)
-    # TODO
-    pytest.set_trace()
     assert response.status_code == 200
     assert http_ok_message in response.content.decode("utf-8")
     assert response_alt.status_code == 200

--- a/content-cache/tests/unit/conftest.py
+++ b/content-cache/tests/unit/conftest.py
@@ -35,7 +35,7 @@ SAMPLE_INTEGRATION_DATA = {
 @pytest.fixture(name="patch_nginx_manager", scope="function")
 def patch_nginx_manager_fixture(monkeypatch, tmp_path: Path) -> None:
     """Patch the nginx_manager module."""
-    monkeypatch.setattr("nginx_manager.NGINX_CONF_PATH", tmp_path / "conf.d")
+    monkeypatch.setattr("nginx_manager.NGINX_CONFD_PATH", tmp_path / "conf.d")
     monkeypatch.setattr("nginx_manager.NGINX_SITES_ENABLED_PATH", tmp_path / "sites-enabled")
     monkeypatch.setattr("nginx_manager.NGINX_SITES_AVAILABLE_PATH", tmp_path / "sites-available")
     monkeypatch.setattr("nginx_manager.NGINX_LOG_PATH", tmp_path / "logs")

--- a/content-cache/tests/unit/conftest.py
+++ b/content-cache/tests/unit/conftest.py
@@ -35,6 +35,7 @@ SAMPLE_INTEGRATION_DATA = {
 @pytest.fixture(name="patch_nginx_manager", scope="function")
 def patch_nginx_manager_fixture(monkeypatch, tmp_path: Path) -> None:
     """Patch the nginx_manager module."""
+    monkeypatch.setattr("nginx_manager.NGINX_CONF_PATH", tmp_path / "conf.d")
     monkeypatch.setattr("nginx_manager.NGINX_SITES_ENABLED_PATH", tmp_path / "sites-enabled")
     monkeypatch.setattr("nginx_manager.NGINX_SITES_AVAILABLE_PATH", tmp_path / "sites-available")
     monkeypatch.setattr("nginx_manager.NGINX_LOG_PATH", tmp_path / "logs")

--- a/content-cache/tests/unit/test_nginx_manager.py
+++ b/content-cache/tests/unit/test_nginx_manager.py
@@ -124,11 +124,11 @@ def test_file_errors(monkeypatch, patch_nginx_manager: None):
     monkeypatch.setattr("nginx_manager.nginx.dumpf", MagicMock(side_effect=OSError("Mock error")))
 
     with pytest.raises(NginxFileError):
-        nginx_manager._create_and_enable_config("mock-host", {})
+        nginx_manager._store_and_enable_site_config("mock-host", {})
 
     monkeypatch.setattr(
         "nginx_manager.nginx.dumpf", MagicMock(side_effect=PermissionError("Mock error"))
     )
 
     with pytest.raises(NginxFileError):
-        nginx_manager._create_and_enable_config("mock-host", {})
+        nginx_manager._store_and_enable_site_config("mock-host", {})


### PR DESCRIPTION
### Overview

<!-- A high level overview of the change -->

Change how the nginx configuration is setup for proxy cache and log format.
These was causing conflicts with multiple virtual hosts.
The integration test is updated to include test with integration to multiple content-cache-backends-config charm to create multiple virtual hosts in the same content-cache charm.

### Rationale

Bug fix to allow multiple virtual hosts in the same content-cache charm.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

The `nginx_manager.py` is updated with the fixed configuration management. 

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes. 

<!-- Explanation for any unchecked items above -->
