### PR TITLE
Feature: Add juju unit name to the cache log name

### DIFF
--- a/content-cache/src/charm.py
+++ b/content-cache/src/charm.py
@@ -163,7 +163,9 @@ class ContentCacheCharm(ops.CharmBase):
 
         status_message = ""
         try:
-            nginx_manager.update_and_load_config(nginx_config, hostname_to_cert)
+            nginx_manager.update_and_load_config(
+                nginx_config, hostname_to_cert, self.unit.name.replace("/", "-")
+            )
         except NginxFileError:
             logger.exception(
                 "Failed to update nginx config file, going to error state for retries"

--- a/content-cache/src/charm.py
+++ b/content-cache/src/charm.py
@@ -96,12 +96,12 @@ class ContentCacheCharm(ops.CharmBase):
 
     def _on_start(self, _: ops.StartEvent) -> None:
         """Handle start event."""
-        _nginx_initialize()
+        self._nginx_initialize()
         self._load_nginx_config()
 
     def _on_stop(self, _: ops.StopEvent) -> None:
         """Handle the stop event."""
-        _nginx_stop()
+        self._nginx_stop()
 
     def _on_update_status(self, _: ops.UpdateStatusEvent) -> None:
         """Handle update status event."""
@@ -164,7 +164,7 @@ class ContentCacheCharm(ops.CharmBase):
         status_message = ""
         try:
             nginx_manager.update_and_load_config(
-                nginx_config, hostname_to_cert, self.unit.name.replace("/", "-")
+                nginx_config, hostname_to_cert, self._get_unit_name()
             )
         except NginxFileError:
             logger.exception(
@@ -199,31 +199,40 @@ class ContentCacheCharm(ops.CharmBase):
         self.unit.status = ops.MaintenanceStatus(RECEIVED_NGINX_CONFIG_MESSAGE)
         return nginx_config
 
+    def _nginx_initialize(self) -> None:
+        """Initialize the nginx instance.
 
-def _nginx_initialize() -> None:
-    """Initialize the nginx instance.
+        Raises:
+            NginxSetupError: Failure to setup nginx.
+        """
+        try:
+            nginx_manager.initialize(self._get_unit_name())
+        except NginxSetupError:
+            logger.exception("Failed to initialize nginx, going to error state for retries")
+            raise
 
-    Raises:
-        NginxSetupError: Failure to setup nginx.
-    """
-    try:
-        nginx_manager.initialize()
-    except NginxSetupError:
-        logger.exception("Failed to initialize nginx, going to error state for retries")
-        raise
+    def _nginx_stop(self) -> None:
+        """Stop the nginx instance.
 
+        Raises:
+            NginxStopError: Failure to stop nginx.
+        """
+        try:
+            nginx_manager.stop()
+        except NginxStopError:
+            logger.exception("Failed to stop nginx, going to error state for retries")
+            raise
 
-def _nginx_stop() -> None:
-    """Stop the nginx instance.
+    def _get_unit_name(self) -> str:
+        """Get a name to identify this unit.
 
-    Raises:
-        NginxStopError: Failure to stop nginx.
-    """
-    try:
-        nginx_manager.stop()
-    except NginxStopError:
-        logger.exception("Failed to stop nginx, going to error state for retries")
-        raise
+        The nginx_manager module needs a name that can be used in file path.
+
+        Returns:
+            The name.
+        """
+        # Replace "/" as it has meaning in a file path.
+        return self.unit.name.replace("/", "_")
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/content-cache/src/charm.py
+++ b/content-cache/src/charm.py
@@ -164,7 +164,7 @@ class ContentCacheCharm(ops.CharmBase):
         status_message = ""
         try:
             nginx_manager.update_and_load_config(
-                nginx_config, hostname_to_cert, self._get_unit_name()
+                nginx_config, hostname_to_cert, self._get_instance_name()
             )
         except NginxFileError:
             logger.exception(
@@ -206,7 +206,7 @@ class ContentCacheCharm(ops.CharmBase):
             NginxSetupError: Failure to setup nginx.
         """
         try:
-            nginx_manager.initialize(self._get_unit_name())
+            nginx_manager.initialize(self._get_instance_name())
         except NginxSetupError:
             logger.exception("Failed to initialize nginx, going to error state for retries")
             raise
@@ -223,7 +223,7 @@ class ContentCacheCharm(ops.CharmBase):
             logger.exception("Failed to stop nginx, going to error state for retries")
             raise
 
-    def _get_unit_name(self) -> str:
+    def _get_instance_name(self) -> str:
         """Get a name to identify this unit.
 
         The nginx_manager module needs a name that can be used in file path.
@@ -231,8 +231,22 @@ class ContentCacheCharm(ops.CharmBase):
         Returns:
             The name.
         """
-        # Replace "/" as it has meaning in a file path.
-        return self.unit.name.replace("/", "_")
+        return unit_name_to_instance_name(self.unit.name)
+
+
+def unit_name_to_instance_name(unit_name: str) -> str:
+    """Transform the unit name to be filepath friendly instance name.
+
+    This logic is in a separate function, to make testing not duplicate logic/code.
+
+    Args:
+        unit_name: The unit name.
+
+    Returns:
+        The instance name.
+    """
+    # Replace "/" as it has meaning in a file path.
+    return unit_name.replace("/", "_")
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/content-cache/src/nginx_manager.py
+++ b/content-cache/src/nginx_manager.py
@@ -498,4 +498,4 @@ def _get_error_log_path(host: str, instance_name: str) -> Path:
     Returns:
         The path.
     """
-    return NGINX_LOG_PATH / instance_name / f"{host}.cache.log"
+    return NGINX_LOG_PATH / instance_name / f"{host}.error.log"

--- a/content-cache/tests/integration/test_metric.py
+++ b/content-cache/tests/integration/test_metric.py
@@ -12,6 +12,7 @@ from juju.model import Model
 from juju.unit import Unit
 
 from src import nginx_manager
+from src.charm import unit_name_to_instance_name
 from tests.integration.helpers import (
     BACKENDS_CONFIG_NAME,
     BACKENDS_PATH_CONFIG_NAME,
@@ -58,7 +59,9 @@ async def test_metric_log(
     response = await cache_tester.query_cache(path="/", hostname=hostname)
     assert response.status_code == 200
 
-    content = await read_file(unit, nginx_manager._get_cache_log_path(hostname))
+    content = await read_file(
+        unit, nginx_manager._get_cache_log_path(hostname, unit_name_to_instance_name(unit.name))
+    )
     assert content
     lines = content.split("\n")
     first_request: dict = json.loads(lines[0])

--- a/content-cache/tests/unit/test_nginx_manager.py
+++ b/content-cache/tests/unit/test_nginx_manager.py
@@ -20,10 +20,12 @@ def test_reset_files_with_missing_dir(patch_nginx_manager: None):
     act: Reset the sites config files.
     assert: The directories exists with the right permissions.
     """
+    mock_instance_name = "mock-test_0"
+
     nginx_manager.NGINX_SITES_ENABLED_PATH.unlink(missing_ok=True)
     nginx_manager.NGINX_SITES_AVAILABLE_PATH.unlink(missing_ok=True)
 
-    nginx_manager._reset_nginx_files()
+    nginx_manager._reset_nginx_files(mock_instance_name)
 
     assert nginx_manager.NGINX_SITES_ENABLED_PATH.exists()
     assert nginx_manager.NGINX_SITES_AVAILABLE_PATH.exists()
@@ -32,13 +34,14 @@ def test_reset_files_with_missing_dir(patch_nginx_manager: None):
     # Not checking for owner, as the test is not necessary run as same user as juju charm (root).
 
 
-def test_reset_file_with_existing_files(patch_nginx_manager: None):
+def test_reset_files_with_existing_files(patch_nginx_manager: None):
     """
     arrange: There are existing files in nginx sites config dir.
     act: Reset the sites config files.
     assert: The directories are empty.
     """
-    nginx_manager._reset_nginx_files()
+    mock_instance_name = "mock-test_0"
+    nginx_manager._reset_nginx_files(mock_instance_name)
     enable_path = nginx_manager._get_sites_enabled_path("unit-test")
     available_path = nginx_manager._get_sites_available_path("unit-test")
     enable_path.touch()
@@ -46,7 +49,7 @@ def test_reset_file_with_existing_files(patch_nginx_manager: None):
     assert enable_path.exists(), "Test setup failure"
     assert available_path.exists(), "Test setup failure"
 
-    nginx_manager._reset_nginx_files()
+    nginx_manager._reset_nginx_files(mock_instance_name)
 
     assert not enable_path.exists()
     assert not available_path.exists()
@@ -60,6 +63,7 @@ def test_update_config_with_valid_config(monkeypatch, patch_nginx_manager: None)
     act: Create configuration files from the data.
     assert: The files are created and has the configurations.
     """
+    mock_instance_name = "mock-test_0"
     monkeypatch.setattr("nginx_manager.execute_command", MagicMock())
     mock_status_check = MagicMock()
     mock_status_check.return_value = True
@@ -79,7 +83,7 @@ def test_update_config_with_valid_config(monkeypatch, patch_nginx_manager: None)
         }
     }
 
-    nginx_manager.update_and_load_config(sample_data, {})
+    nginx_manager.update_and_load_config(sample_data, {}, mock_instance_name)
 
     config_file_content = nginx_manager._get_sites_enabled_path(hostname).read_text()
 


### PR DESCRIPTION
### Overview

Add juju unit name to the cache log name.
E.g.: 
`/var/log/nginx/ubuntu.com.cache.log` -> `/var/log/nginx/juju-unit-name-0/ubuntu.com.cache.log`

### Rationale

1. Avoid collusion of log file in grafana (of COS) between different content-cache deployment. This splits the log files which allows for the point 2.
2. A feature request was to be able to filter by juju unit names (e.g., content-cache-0) rather than the hostname (e.g., juju-b2fc87-14). This change would make it much easier and cleaner to support this feature.

### Module Changes

Change the log path name functions in `nginx_manager.py`.

The interface usage change in `charm.py` is as follow:

```
nginx_manager.update_and_load_config(nginx_config, hostname_to_cert)
```

to 

```
nginx_manager.update_and_load_config(
    nginx_config, hostname_to_cert, self.unit.name.replace("/", "-")
)
```

Basically, the juju unit name needs to be passed to a `nginx_manager` function, so the logs file path can include the unit name.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes. 

<!-- Explanation for any unchecked items above -->

The changelog.md is not changed due to this is to support a not yet released feature. The changelog will be update when the feature (metric dashboard) is released.
