### PR TITLE
Fix the default channel for charm revision actions

### DIFF
--- a/.github/workflows/promote_charm_backends_config.yaml
+++ b/.github/workflows/promote_charm_backends_config.yaml
@@ -7,12 +7,12 @@ on:
         type: choice
         description: 'Origin Channel'
         options:
-        - latest/edge
+        - 1/edge
       destination-channel:
         type: choice
         description: 'Destination Channel'
         options:
-        - latest/stable
+        - 1/stable
     secrets:
       CHARMHUB_TOKEN:
         required: true

--- a/.github/workflows/publish_charm_backends_config.yaml
+++ b/.github/workflows/publish_charm_backends_config.yaml
@@ -11,5 +11,5 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
     with:
-      channel: latest/edge
+      channel: 1/edge
       working-directory: ./content-cache-backends-config


### PR DESCRIPTION


### Overview

<!-- A high level overview of the change -->
Fix the default channel for charm revision promotion and upload.

### Rationale

<!-- The reason the change is needed -->
The `1/edge` channel is the channel the charm rewrite uses.


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [xj] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes. 

<!-- Explanation for any unchecked items above -->
