### PR TITLE
Fix publish charm and promote charm workflow

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
 
 jobs:
+  # This test the content-cache and content-cache-backends-config charms together.
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
@@ -14,3 +15,13 @@ jobs:
       working-directory: ./content-cache
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
+  # This is for building the content-cache-backends-config charm for the publish charm workflow.
+  build-content-cache-backends-config:
+    # Only build if the integration test succeeds.
+    needs: integration-tests
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      juju-channel: 3.6/stable
+      provider: lxd
+      working-directory: ./content-cache-backends-config

--- a/.github/workflows/promote_charm_content_cache.yaml
+++ b/.github/workflows/promote_charm_content_cache.yaml
@@ -1,4 +1,4 @@
-name: Promote charm for content-cache-backends-config
+name: Promote charm for content-cache
 
 on:
   workflow_dispatch:
@@ -7,12 +7,12 @@ on:
         type: choice
         description: 'Origin Channel'
         options:
-        - latest/edge
+        - 1/edge
       destination-channel:
         type: choice
         description: 'Destination Channel'
         options:
-        - latest/stable
+        - 1/stable
     secrets:
       CHARMHUB_TOKEN:
         required: true

--- a/.github/workflows/publish_charm_backends_config.yaml
+++ b/.github/workflows/publish_charm_backends_config.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+      # DEBUG
+      - fix/publish-promote-charm
 
 jobs:
   publish-to-edge:

--- a/.github/workflows/publish_charm_backends_config.yaml
+++ b/.github/workflows/publish_charm_backends_config.yaml
@@ -1,0 +1,15 @@
+name: Publish to edge for content-cache-backends-config
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-to-edge:
+    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    secrets: inherit
+    with:
+      channel: latest/edge
+      working-directory: ./content-cache-backends-config

--- a/.github/workflows/publish_charm_backends_config.yaml
+++ b/.github/workflows/publish_charm_backends_config.yaml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-      # DEBUG
-      - fix/publish-promote-charm
 
 jobs:
   publish-to-edge:

--- a/.github/workflows/publish_charm_content_cache.yaml
+++ b/.github/workflows/publish_charm_content_cache.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+      # DEBUG
+      - fix/publish-promote-charm
 
 jobs:
   publish-to-edge:

--- a/.github/workflows/publish_charm_content_cache.yaml
+++ b/.github/workflows/publish_charm_content_cache.yaml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-      # DEBUG
-      - fix/publish-promote-charm
 
 jobs:
   publish-to-edge:

--- a/.github/workflows/publish_charm_content_cache.yaml
+++ b/.github/workflows/publish_charm_content_cache.yaml
@@ -1,4 +1,4 @@
-name: Publish to edge content-cache
+name: Publish to edge for content-cache
 
 on:
   workflow_dispatch:

--- a/content-cache-backends-config/tox.ini
+++ b/content-cache-backends-config/tox.ini
@@ -100,16 +100,10 @@ commands =
     bandit -c {toxinidir}/pyproject.toml -r {[vars]src_path} {[vars]tst_path}
 
 [testenv:integration]
-description = Run integration tests
-deps =
-    # Last compatible version with Juju 2.9
-    juju==3.0.4
-    pytest
-    pytest-asyncio
-    pytest-operator
-    -r{toxinidir}/requirements.txt
+description = Print where the integration tests are located
+allowlist_externals = echo
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    echo "Integration test are combined with content-cache charm in the content-cache directory"
 
 [testenv:src-docs]
 allowlist_externals=sh


### PR DESCRIPTION
### Overview

<!-- A high level overview of the change -->
Fix the publish charm and promote charm workflows.

The content-cache should go to the `1` track instead of the `latest`.
The content-cache-backends-config should go to the `latest` track.

### Rationale

<!-- The reason the change is needed -->
This should update the workflow files to the correct `working-directory` and other settings.
 
### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes. 

<!-- Explanation for any unchecked items above -->
