### PR TITLE
Enable proxy_cache_revalidate by default

### DIFF
--- a/content-cache/src/nginx_manager.py
+++ b/content-cache/src/nginx_manager.py
@@ -514,6 +514,7 @@ def _get_location_config_keys(
     keys = [
         nginx.Key("proxy_pass", f"{config.protocol.value}://{upstream}{config.backends_path}"),
         nginx.Key("proxy_set_header", f'Host "{host}"'),
+        nginx.Key("proxy_cache_revalidate", "on"),
     ]
 
     for cache_valid in config.proxy_cache_valid:

--- a/content-cache/tests/unit/test_nginx_manager.py
+++ b/content-cache/tests/unit/test_nginx_manager.py
@@ -96,6 +96,7 @@ def test_update_config_with_valid_config(monkeypatch, patch_nginx_manager: None)
     assert "server_name example.com" in config_file_content
     assert "access_log" in config_file_content
     assert "error_log" in config_file_content
+    assert "proxy_cache_revalidate on" in config_file_content
 
     healthchecks_config_file_content = nginx_manager.NGINX_HEALTHCHECKS_CONF_PATH.read_text()
     assert "GET /health" in healthchecks_config_file_content


### PR DESCRIPTION
### Overview

<!-- A high level overview of the change -->
Enable `proxy-cache-revalidate` by default.

### Rationale

<!-- The reason the change is needed -->
This was requested for the k8s content-cache and makes sense for the this charm as well.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The docs/changelog.md is updated with user-relevant changes. 

<!-- Explanation for any unchecked items above -->
