### PR TITLE
Add additional configuration for healthchecks

### DIFF
--- a/content-cache-backends-config/config.yaml
+++ b/content-cache-backends-config/config.yaml
@@ -47,6 +47,16 @@ options:
       The time between two health checks (in milliseconds)
     type: int
     default: 10000
+  healthcheck-valid-status:
+    description: |
+      A comma-separated list of valid statuses for the healtchecks.
+    type: string
+    default: 200
+  healthcheck-ssl-verify:
+    description: |
+      A boolean to bypass ssl verification for healthchecks.
+    type: boolean
+    default: true
   proxy-cache-valid:
     description: |
       A list of HTTP response code(s) followed by a cache valid duration. For example ["200 302 1h


### PR DESCRIPTION
Applicable spec: ISD183

### Overview

The current active healthchecks only support 200 as a valid status code. It also only support valid ssl certificate for backends.
It's a limitation as for internal deployments users may have self signed certificates.

This PR proposed to introduce the following configuration options to have more flexibility:
- healthchecks-valid-status: to support more statuses than 200 (e.g. 301)
- healthchecks-ssl-verify: to support self-signed certificates.

### Rationale

With these two additional parameters, SRE should be able to handle all the specific situations they may encounter with the backends.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes. 

<!-- Explanation for any unchecked items above -->
