### PR TITLE
Open ports

### DIFF
--- a/content-cache/src/charm.py
+++ b/content-cache/src/charm.py
@@ -147,6 +147,7 @@ class ContentCacheCharm(ops.CharmBase):
                 self.certificates,
             )
             logger.info("Found all certificate requested")
+            self.unit.open_port("tcp", 443)
         except TLSCertificateIntegrationNotExistError:
             logger.info("Skipping TLS certificates as tls-certificate integration not found")
         except TLSCertificateFileError:
@@ -207,6 +208,7 @@ class ContentCacheCharm(ops.CharmBase):
         """
         try:
             nginx_manager.initialize(self._get_instance_name())
+            self.unit.open_port("tcp", 80)
         except NginxSetupError:
             logger.exception("Failed to initialize nginx, going to error state for retries")
             raise

--- a/content-cache/src/charm.py
+++ b/content-cache/src/charm.py
@@ -147,7 +147,6 @@ class ContentCacheCharm(ops.CharmBase):
                 self.certificates,
             )
             logger.info("Found all certificate requested")
-            self.unit.open_port("tcp", 443)
         except TLSCertificateIntegrationNotExistError:
             logger.info("Skipping TLS certificates as tls-certificate integration not found")
         except TLSCertificateFileError:
@@ -208,7 +207,7 @@ class ContentCacheCharm(ops.CharmBase):
         """
         try:
             nginx_manager.initialize(self._get_instance_name())
-            self.unit.open_port("tcp", 80)
+            self.unit.set_ports(80, 443)
         except NginxSetupError:
             logger.exception("Failed to initialize nginx, going to error state for retries")
             raise


### PR DESCRIPTION
Open ports assuming we open port 80 per default and 443 only if we could process certificates successfully.

Port 80 remains open even when 443 is active to redirect clients (as defined in the spec).