### PR TITLE
Specify base image

### DIFF
--- a/.github/workflows/promote_charm_content_cache.yaml
+++ b/.github/workflows/promote_charm_content_cache.yaml
@@ -24,4 +24,8 @@ jobs:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
       working-directory: ./content-cache
+      base-channel: 24.04
+      base-name: ubuntu
+      base-architecture: amd64
+      doc-automation-disabled: false
     secrets: inherit


### PR DESCRIPTION
Current "promote_charm" workflow is failing because it tries to publish on a 18.04 image which is note supported.
The new release of the charm only support 24.04, so I'm setting the promote_charm workflow to use this as a base.