### PR TITLE
Re-check Vale and fix errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Content Cache
+# Content cache charms
 
 This repository contains the code for two charms:
 1. `content-cache`: A machine charm managing a nginx instance configured as a content cache. See the [content-cache README](content-cache/README.md) for more information.

--- a/content-cache-backends-config/README.md
+++ b/content-cache-backends-config/README.md
@@ -8,7 +8,7 @@ Avoid using this README file for information that is maintained or published els
 Use links instead.
 -->
 
-# Content Cache Backends Config Operator
+# Content cache backends config operator
 
 A [Juju](https://juju.is/) [subordinate](https://juju.is/docs/sdk/charm-taxonomy#heading--subordinate-charms) [charm](https://juju.is/docs/olm/charmed-operators) to the [Content Cache charm](https://charmhub.io/content-cache) which provides the Content Cache charm with the configuration required to expose a set of backend services behind caching capabilities of the Content Cache charm.
 

--- a/content-cache-backends-config/docs/changelog.md
+++ b/content-cache-backends-config/docs/changelog.md
@@ -8,7 +8,7 @@
 
 ## 2025-01-13
 
-### ** Added**
+### **Added**
 
 - Support for healthcheck-valid-status charm configurations.
 - Support for healthcheck-ssl-verify charm configurations.


### PR DESCRIPTION
Applicable ticket: ISD-3949

### Overview

Run Vale checks locally and fix errors.

### Rationale

There's a bug in operator-workflows that points to an older version of the Canonical Vale style checks. Therefore some of the checks will be missed in the GitHub CI.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The docs/changelog.md is updated with user-relevant changes. 

<!-- Explanation for any unchecked items above -->
There are no `src` docs. Either discourse-gatekeeper will update the documentation on Charmhub or I'll do it after the approval of this PR. Since these are trivial changes, I don't think the changelog needs to be updated.