### PR TITLE
Reference the old documentation page

### DIFF
--- a/content-cache/metadata.yaml
+++ b/content-cache/metadata.yaml
@@ -14,7 +14,7 @@ display-name: Content Cache
 
 # (Required)
 summary: A charm for managing a content cache with nginx.
-docs: https://discourse.charmhub.io/t/content-cache-documentation-overview/16503
+docs: https://discourse.charmhub.io/t/content-cache-docs-index/5389
 issues: https://github.com/canonical/content-cache-operator/issues
 maintainers: 
   - https://launchpad.net/~canonical-is-devops


### PR DESCRIPTION
It seems that we cannot change the discourse link once a charm has been published.

In this PR I update the charm documentation to refer to the existing page, and in parallel I'm switching the content of the odl page and the new page on discourse. The new page will reference the old one.