### PR TITLE
Use new team name in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/is-charms
+*       @canonical/platform-engineering

--- a/content-cache-backends-config/tox.ini
+++ b/content-cache-backends-config/tox.ini
@@ -47,7 +47,7 @@ deps =
     pep8-naming
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest
     pytest-asyncio
     pytest-operator

--- a/content-cache-backends-config/tox.ini
+++ b/content-cache-backends-config/tox.ini
@@ -36,7 +36,7 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
+    flake8
     flake8-builtins
     flake8-copyright<6.0.0
     flake8-docstrings>=1.6.0

--- a/content-cache/src/nginx_manager.py
+++ b/content-cache/src/nginx_manager.py
@@ -483,7 +483,7 @@ def _get_upstream_healthchecks_worker(upstream: str, config: LocationConfig) -> 
             upstream = "{upstream}",
             type = "{config.protocol.value}",
 
-            http_req = "GET {config.healthcheck_config.path} HTTP/1.0\r\nHost: {config.hostname}\r\n\r\n",
+            http_req = "GET {config.healthcheck_config.path} HTTP/1.0\r\nHost: {config.hostname}\r\n\r\n",  # noqa: line-too-long
 
             port = {getservbyname(config.protocol.value)},
             interval = {config.healthcheck_config.interval},

--- a/content-cache/src/nginx_manager.py
+++ b/content-cache/src/nginx_manager.py
@@ -483,7 +483,7 @@ def _get_upstream_healthchecks_worker(upstream: str, config: LocationConfig) -> 
             upstream = "{upstream}",
             type = "{config.protocol.value}",
 
-            http_req = "GET {config.healthcheck_config.path} HTTP/1.0\r\nHost: {config.hostname}\r\n\r\n",  # noqa: line-too-long
+            http_req = "GET {config.healthcheck_config.path} HTTP/1.0\r\nHost: {config.hostname}\r\n\r\n",
 
             port = {getservbyname(config.protocol.value)},
             interval = {config.healthcheck_config.interval},
@@ -499,7 +499,7 @@ def _get_upstream_healthchecks_worker(upstream: str, config: LocationConfig) -> 
             ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
             return
         end
-    """
+    """  # noqa: line-too-long
 
 
 def _get_location_config_keys(

--- a/content-cache/src/nginx_manager.py
+++ b/content-cache/src/nginx_manager.py
@@ -478,12 +478,13 @@ def _get_upstream_healthchecks_worker(upstream: str, config: LocationConfig) -> 
         A string with the lua script for the healthcheck workers.
     """
     valid_status_str = ",".join(str(status) for status in config.healthcheck_config.valid_status)
+    hc_path = config.healthcheck_config.path
     return rf"""ok, err = hc.spawn_checker{{
             shm = "healthcheck",
             upstream = "{upstream}",
             type = "{config.protocol.value}",
 
-            http_req = "GET {config.healthcheck_config.path} HTTP/1.0\r\nHost: {config.hostname}\r\n\r\n",
+            http_req = "GET {hc_path} HTTP/1.0\r\nHost: {config.hostname}\r\n\r\n",
 
             port = {getservbyname(config.protocol.value)},
             interval = {config.healthcheck_config.interval},
@@ -499,7 +500,7 @@ def _get_upstream_healthchecks_worker(upstream: str, config: LocationConfig) -> 
             ngx.log(ngx.ERR, "failed to spawn health checker: ", err)
             return
         end
-    """  # noqa: line-too-long
+    """
 
 
 def _get_location_config_keys(

--- a/content-cache/tox.ini
+++ b/content-cache/tox.ini
@@ -47,7 +47,7 @@ deps =
     pep8-naming
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest
     pytest-asyncio
     pytest-operator

--- a/content-cache/tox.ini
+++ b/content-cache/tox.ini
@@ -36,7 +36,7 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
+    flake8
     flake8-builtins
     flake8-copyright<6.0.0
     flake8-docstrings>=1.6.0


### PR DESCRIPTION
Replace references to is-charms to platform-engineering in CODEOWNERS