### PR TITLE
chore(docs): Add Charmhub listing table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ This repository contains the code for two charms:
 1. `content-cache`: A machine charm managing a nginx instance configured as a content cache. See the [content-cache README](content-cache/README.md) for more information.
 2. `content-cache-backends-config`: A subordinate charm providing the configuration required to expose a set of backend services. See the [content-cache-backends-config README](content-cache-backends-config/README.md) for more information.
 
+## Charmhub
+
+| Name | Listing |
+|------------|------------------|
+| `content-cache`                 | https://charmhub.io/content-cache |
+| `content-cache-backends-config` | https://charmhub.io/content-cache-backends-config |
+
 ## Documentation
 
 Our documentation is stored in the `docs` directory


### PR DESCRIPTION
#### What this PR does

Adds a table with Charmhub URLs for the charms in this monorepo.

#### Why we need it

Enables discoverability for both humans and LLMs.
