### PR TITLE
chore: codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/platform-engineering
+*       @canonical/platform-engineering-apac


### PR DESCRIPTION
Fixes the repolint 'codeowners' check: assigns CODEOWNERS to the regional team `@canonical/platform-engineering-apac` (per the repo's `squad-apac` topic) instead of the generic `@canonical/platform-engineering` team.